### PR TITLE
update tag for SPDX license IDs

### DIFF
--- a/copyright-statements/README.md
+++ b/copyright-statements/README.md
@@ -17,7 +17,7 @@ The 'develop' branch is the most up to date and is the branch that should be use
 
 This script is licensed under the GNU GPL 3 license.
 
-SPDX-Identifier: GPL-3.0-only.
+SPDX-License-Identifier: GPL-3.0-only
 
 # Adding the SPDX license list data
 

--- a/copyright-statements/createnotices.py
+++ b/copyright-statements/createnotices.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Copyright Armijn Hemel for Tjaldur Software Governance Solutions
-# SPDX-Identifier: GPL-3.0-only
+# SPDX-License-Identifier: GPL-3.0-only
 
 # This scripts processes output of ScanCode 3.0.x and outputs a file
 # with license information, author information and copyright statements,

--- a/diffstatverifier/README.md
+++ b/diffstatverifier/README.md
@@ -40,4 +40,4 @@ script should be regarded as a baseline.
 
 # License
 
-SPDX-Identifier: GPL-3.0-only
+SPDX-License-Identifier: GPL-3.0-only

--- a/diffstatverifier/diffstatverifier.py
+++ b/diffstatverifier/diffstatverifier.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Copyright Armijn Hemel for Tjaldur Software Governance Solutions
-# SPDX-Identifier: GPL-3.0-only
+# SPDX-License-Identifier: GPL-3.0-only
 
 # This scripts processes a list of strings from the Linux kernel and
 # compares it to the output of a Git diffstat to see if there are matches.

--- a/doc/build-instructions-sample.txt
+++ b/doc/build-instructions-sample.txt
@@ -1,4 +1,4 @@
-SPDX-Identifier: CC0-1.0
+SPDX-License-Identifier: CC0-1.0
 
 These are the build instructions to rebuild the open source components for XXX Frobinator.
 

--- a/doc/build-instructions-template.txt
+++ b/doc/build-instructions-template.txt
@@ -1,4 +1,4 @@
-SPDX-Identifier: CC0-1.0
+SPDX-License-Identifier: CC0-1.0
 
 These are the build instructions to rebuild the open source components for XXX.
 

--- a/doc/source-code-analysis.md
+++ b/doc/source-code-analysis.md
@@ -1,4 +1,4 @@
-SPDX-Identifier: CC0-1.0
+SPDX-License-Identifier: CC0-1.0
 
 This file documents the steps typically needed to find common issues in source code releases.
 

--- a/docker/walkdockerrepository.py
+++ b/docker/walkdockerrepository.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 # Copyright 2018 Armijn Hemel for Tjaldur Software Governance Solutions
-# SPDX-Identifier: GPL-3.0
+# SPDX-License-Identifier: GPL-3.0
 
 # This scripts processes a Docker data structure and pretty prints some
 # statistics about it.


### PR DESCRIPTION
Just fixing the tag for SPDX license ID statements in a few files, so that they'll be detected by folks looking for the typical statement from https://spdx.dev/ids/

Signed-off-by: Steve Winslow <steve@swinslow.net>